### PR TITLE
Updates SqlitePatterns to be able to parse/format a NodaTime value

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
 <Project>
   <ItemGroup>
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
-    <PackageReference Update="NodaTime" Version="3.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.5" />
+    <PackageReference Update="NodaTime" Version="3.0.5" />
 
     <!-- Test -->
     <PackageReference Update="Verify.Xunit" Version="8.12.5" />

--- a/EFCore.Sqlite.NodaTime/EFCore.Sqlite.NodaTime.csproj
+++ b/EFCore.Sqlite.NodaTime/EFCore.Sqlite.NodaTime.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>EntityFrameworkCore.Sqlite.NodaTime</AssemblyName>
     <PackageId>EntityFrameworkCore.Sqlite.NodaTime</PackageId>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.0.2</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.Sqlite.NodaTime/Storage/Internal/SqlitePatterns.cs
+++ b/EFCore.Sqlite.NodaTime/Storage/Internal/SqlitePatterns.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     internal static class SqlitePatterns
     {
-        private const string DateTimePattern = "uuuu'-'MM'-'dd' 'HH':'mm':'ss'.'FFFFFFFFF";
+        private const string DateTimePattern = "uuuu-MM-dd HH:mm:ss.FFFFFFFFF";
 
         internal static readonly IPattern<LocalDateTime> LocalDateTime = LocalDateTimePattern.CreateWithInvariantCulture(DateTimePattern);
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "5.0.202",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
Updates SqlitePatterns (fixes #4) to be able to parse/format a NodaTime value back and forth

I also 
Updates NodaTime to latest version
Updates Microsoft.EntityFrameworkCore.Sqlite to latest available version.